### PR TITLE
Updated description of superseded reason code

### DIFF
--- a/rootstore/policy.md
+++ b/rootstore/policy.md
@@ -801,8 +801,8 @@ Otherwise, the affiliationChanged CRLReason MUST NOT be used.
 
 **superseded**
 
-The CRLReason superseded is intended to be used to indicate when:
-*   the certificate subscriber has requested a new certificate to replace an existing certificate; or
+The CRLReason superseded is intended to be used to indicate the certificate is being replaced because:
+*   the certificate subscriber has requested a new certificate;
 *   the CA operator obtains reasonable evidence that the validation of domain authorization or control for any fully‐qualified domain name or IP address in the certificate should not be relied upon; *or*
 *   the CA operator has revoked the certificate for compliance reasons such as the certificate does not comply with this policy, the CA/Browser Forum's Baseline Requirements, or the CA operator’s CP or CPS.
 


### PR DESCRIPTION
As discussed in Issue #254 (Harmonize CRL Reason Codes), this change updates the description of the "superseded" reason code to conform to section 7.2.2 of the CA/B Forum's Baseline Requirements per Ballot SC-061 v. 4, which says  “superseded (RFC 5280 CRLReason #4): Indicates that the Certificate is being replaced because: the Subscriber has requested a new Certificate, the CA has reasonable evidence that the validation of domain authorization or control for any fully‐qualified domain name or IP address in the Certificate should not be relied upon, or the CA has revoked the Certificate for compliance reasons such as the Certificate does not comply with these Baseline Requirements or the CA's CP or CPS;”